### PR TITLE
Better naming for variable: LINES -> NUM_LINES

### DIFF
--- a/bin/bin/utils/ocr
+++ b/bin/bin/utils/ocr
@@ -46,8 +46,8 @@ sed -i 's/\x0c//' "$TEXT_FILE"
 
 # Check if the text was detected by checking number
 # of lines in the file
-LINES=$(wc -l < $TEXT_FILE)
-if [ "$LINES" -eq 0 ]; then
+NUM_LINES=$(wc -l < $TEXT_FILE)
+if [ "$NUM_LINES" -eq 0 ]; then
     notify-send "ocr" "no text was detected"
     exit 1
 fi


### PR DESCRIPTION
The variable doesn't hold the lines themselfs (as the old name suggested), but the _number_ of lines in TEXT_FILE. The name of the variable should reflect that.