### PR TITLE
Remove $image_file after not detecting QR code.

### DIFF
--- a/bin/bin/utils/qrshot
+++ b/bin/bin/utils/qrshot
@@ -38,7 +38,7 @@ decoded_text=$(zbarimg "$image_file" -q --raw)
 
 if [ -z "$decoded_text" ]; then
     notify-send "qrshot" "no text was detected"
-    exit 1
+    rm $image_file && exit 1
 fi
 
 # Copy text to clipboard


### PR DESCRIPTION
If you don't remove the file after not detecting a QR code, the next time you try it, it will use the same file.