### PR TITLE
update: bin/utils/fwifi

### DIFF
--- a/bin/bin/utils/fwifi
+++ b/bin/bin/utils/fwifi
@@ -26,12 +26,7 @@ die() {
 
 has -v nmcli fzf || die
 
-nmcli -d wifi rescan 2> /dev/null
-network=$(nmcli --color yes device wifi | fzf --ansi --height=40% --reverse --cycle --inline-info --header-lines=1)
-#network=$(nmcli device wifi | dmenu)
-[[ -z "$network" ]] && exit
-network=$(sed -r 's/^\s*\*?\s*//; s/\s*(Ad-Hoc|Infra).*//' <<< "$network")
-SSID=$(echo "$network" | grep -o "\s.*$" | xargs)
+SSID=$(nmcli --color yes device wifi | fzf --ansi --height=40% --reverse --cycle --inline-info --header-lines=1 | awk '{print $2}')
+[[ -z "$SSID" ]] && exit
 echo "connecting to \"${SSID}\"..."
 nmcli -a device wifi connect "$SSID"
-


### PR DESCRIPTION
Hi,
I Randomly came across this scrip and I made some changes that you might find useful.
1. remove `nmcli -d wifi rescan`. As it no longer exist, and it's not needed here. 
```Shell
❯ nmcli -d wifi rescan
Error: Option '-d' is unknown, try 'nmcli -help'.
```
2. Parse the network SSID in one `awk` command 
```diff
- network=$(nmcli --color yes device wifi | fzf --ansi --height=40% --reverse --cycle --inline-info --header-lines=1)
- #network=$(nmcli device wifi | dmenu)
- [[ -z "$network" ]] && exit
- network=$(sed -r 's/^\s*\*?\s*//; s/\s*(Ad-Hoc|Infra).*//' <<< "$network")
- SSID=$(echo "$network" | grep -o "\s.*$" | xargs)
+ SSID=$(nmcli --color yes device wifi | fzf --ansi --height=40% --reverse --cycle --inline-info --header-lines=1 | awk '{print $2}')
+ [[ -z "$SSID" ]] && exit
+ echo "connecting to \"${SSID}\"..."
```